### PR TITLE
Update stylesheet to reflect new style

### DIFF
--- a/app/views/layouts/default.rhtml
+++ b/app/views/layouts/default.rhtml
@@ -19,6 +19,9 @@
   <%= stylesheet_link_tag 'instiki', :media => 'all'  unless @inline_style %>
   <%= stylesheet_link_tag 'mathematics', :media => 'all'  unless @inline_style %>
   <%= stylesheet_link_tag 'syntax', :media => 'all'  unless @inline_style %>
+  <%= stylesheet_link_tag 'nlab', :media => 'all' %>
+  <link rel="stylesheet" type="text/css" href="https://cdn.rawgit.com/dreampulse/computer-modern-web-font/master/fonts.css">
+
   <style type="text/css">
     h1#pageName, div.info, .newWikiWord a, a.existingWikiWord, .newWikiWord a:hover, [actiontype="toggle"]:hover, #TextileHelp h3 {
       color: #<%= @web ? @web.color : "262" %>;

--- a/public/stylesheets/nlab.css
+++ b/public/stylesheets/nlab.css
@@ -162,6 +162,28 @@ td, th {
         margin-top: 100px;
    }
 }
+
 a[href="#navEnd"] {
 	display: none;
+}
+p, li {
+    line-height: 1.4em;
+    font-size: 18px;
+}
+
+.navigation span.views {
+	font-family: Sans-Serif;
+	margin-left: 30px;
+}
+
+.navigation a {
+	font-weight: normal;
+}
+
+a.existingWikiWord {
+    color: #009600;
+}
+
+a.existingWikiWord:visited {
+    color: #00b121;
 }

--- a/public/stylesheets/nlab.css
+++ b/public/stylesheets/nlab.css
@@ -1,0 +1,152 @@
+body {
+    font-family: 'Computer Modern Serif', Serif !important;
+}
+h1, h2, h3, h4, h5, h6 {
+    font-family: 'Computer Modern Serif', Serif !important;
+    font-weight: normal;
+}
+h2 {
+    margin-top: 65px;
+    font-size: 1.8em;
+}
+h3 {
+    font-weight: bold;
+    font-style: italic;
+    margin-top: 50px;
+}
+p, li {
+    line-height: 2em;
+    font-size: 18px;
+}
+.query {
+    border-radius: 3px;
+    padding: 0 40px;
+    border-width: 1px;
+    margin: 40px 0;
+}
+strong {
+    font-style: italic;
+}
+span.theorem_label {
+    font-style: italic;
+}
+a {
+    text-decoration: none;
+    color: #222;
+}
+a:hover {
+    color: #555;
+    background: none;
+}
+a:hover.existingWikiWord {
+    color: #555;
+    background: none;
+}
+img, svg {
+    margin: 40px auto;
+    display: block;
+}
+h1#pageName {
+    font-size: 2.8em;
+    margin-bottom: 50px;
+    margin-top: 50px;
+    color: #000;
+}
+.maruku-equation {
+    font-size: 1.3em;
+}
+.navigation:not(.navfoot) {
+    position: absolute;
+    top: 10px;
+    right: 20px;
+    padding: 15px;
+    color: #888;
+    font-size: 0;
+}
+.navigation a {
+    color: #888!important;
+    font-weight: normal;
+    font-size: 13px;
+    margin: 0 10px;
+    font-family: Sans-Serif;
+    font-weight: lighter;
+   ;
+}
+.navigation.navfoot {
+    margin: 50px 0;
+}
+#pageName > span {
+    position: absolute;
+    font-size: .45em;
+    top: 10px;
+    left: 20px;
+}
+#pageName > span > svg {
+    margin: 0;
+}
+#pageName > span.webName {
+    left: 70px;
+    top: 17px;
+    color: #555;
+    font-family: Sans-Serif;
+    font-weight: lighter;
+}
+div.rightHandSide {
+    border-radius: 3px;
+    border: 1px solid rgba(0, 0, 0, 0.1);
+    border-right: 0;
+    border-top: 0;
+}
+.maruku_toc li{
+    line-height: 1.3em;
+}
+.maruku_toc li a{
+    color: #226622;
+}
+.maruku_toc li a:hover {
+    color: #555;
+}
+.maruku_toc li a:visited{
+    color: #164416;
+}
+.maruku_toc ul {
+    margin-top: 20px;
+}
+h1#contents {
+    font-size: 1.5em;
+}
+input[type=text]#searchField {
+    width: 100%;
+    padding: 5px 10px;
+    display: inline-block;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    box-sizing: border-box;
+    font-size: 13px;
+    margin-bottom: -5px;
+    margin-left: 10px;
+    color: #555;
+}
+table {
+    border: 0;
+    margin: auto;
+}
+td, th {
+    border: 1px solid #dddddd;
+    text-align: left;
+    padding: 8px;
+}
+.rightHandSide h3 {
+    margin-top: 20px;
+}
+.rightHandSide h2 {
+    margin-top: 20px;
+}
+@media only screen and (max-width: 960px) {
+    .navigation:not(.navfoot) {
+        top: 60px;
+   }
+    h1#pageName {
+        margin-top: 100px;
+   }
+}

--- a/public/stylesheets/nlab.css
+++ b/public/stylesheets/nlab.css
@@ -15,7 +15,7 @@ h3 {
     margin-top: 50px;
 }
 p, li {
-    line-height: 2em;
+    line-height: 1.6em;
     font-size: 18px;
 }
 .query {
@@ -35,13 +35,19 @@ a {
     color: #222;
 }
 a:hover {
-    color: #555;
+    color: #2c66d8;
     background: none;
+    text-decoration: underline;
 }
 a:hover.existingWikiWord {
-    color: #555;
+    color: #2c66d8;
     background: none;
 }
+a:visited:hover.existingWikiWord {
+    color: #2c66d8;
+    background: none;
+}
+
 img, svg {
     margin: 40px auto;
     display: block;
@@ -70,8 +76,12 @@ h1#pageName {
     margin: 0 10px;
     font-family: Sans-Serif;
     font-weight: lighter;
-   ;
 }
+.navigation a:hover {
+    color: #555!important;
+	background:none;
+}
+
 .navigation.navfoot {
     margin: 50px 0;
 }
@@ -104,14 +114,16 @@ div.rightHandSide {
     color: #226622;
 }
 .maruku_toc li a:hover {
-    color: #555;
+    color: #2c66d8;
 }
 .maruku_toc li a:visited{
     color: #164416;
 }
-.maruku_toc ul {
-    margin-top: 20px;
+
+.maruku_toc li a:visited:hover{
+    color: #2c66d8;
 }
+
 h1#contents {
     font-size: 1.5em;
 }
@@ -149,4 +161,7 @@ td, th {
     h1#pageName {
         margin-top: 100px;
    }
+}
+a[href="#navEnd"] {
+	display: none;
 }


### PR DESCRIPTION
Implements a new style for nlab

<img width="1438" alt="Screen Shot 2019-04-02 at 2 45 34 PM" src="https://user-images.githubusercontent.com/5866348/55407553-0e7afb80-5556-11e9-966d-5966e361a345.png">

Context: https://nforum.ncatlab.org/discussion/9691/style-changes/?Focus=76978#Comment_76978

- This PR contains only CSS changes
- The style is reminiscent of what I implemented in [Kan](https://sites.google.com/keplr.io/kan), but contains no functionality changes, and the change here is more conservative. For example, the margins around table of contents remain quite small, and there's no major layout changes.

Richard, I haven't been able to set up a local copy of nlab to test with (as you pointed out that's quite tedious), please check that the changes I made are correct. Thanks!