### PR TITLE
Upgrade dependencies for nlab-rails

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,8 +15,9 @@ gem "rails_xss", "~> 0.4.0"
 gem "file_signature", "~> 1.2.0"
 gem "syntax", "~> 1.1.0"
 gem "maruku", :git => 'https://github.com/distler/maruku.git', :branch => 'nokogiri'
-gem 'iconv', :platforms => [:ruby_20, :ruby_21, :ruby_22]
+gem 'iconv'
 gem 'rdoc-data', :platforms => :ruby_18
-gem "mysql", ">=2.9.1"
+gem "mysql2"
+gem "activerecord-mysql2-adapter"
 gem "will_paginate", "~> 2.3.15"
 gem "diff-lcs", "~> 1.1.2"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,75 @@
+GIT
+  remote: https://github.com/adeel/itextomml.git
+  revision: 2cd52cdeba7123fcd52d6d64e150f24c644f8e0f
+  specs:
+    itextomml (1.5.6)
+
+GIT
+  remote: https://github.com/distler/maruku.git
+  revision: 588716382cfa77806ccd79fff6d97a3d6caba454
+  branch: nokogiri
+  specs:
+    maruku (0.7.3.beta1)
+      itextomml (>= 1.5.0)
+      nokogiri (~> 1.5, >= 1.5.6)
+      syntax (~> 1.1.0)
+
+GEM
+  remote: http://rubygems.org/
+  specs:
+    RedCloth (4.3.2)
+    abstract (1.0.0)
+    activerecord-mysql2-adapter (0.0.3)
+      mysql2
+    diff-lcs (1.1.3)
+    erubis (2.7.0)
+    file_signature (1.2.0)
+    iconv (1.0.8)
+    json (2.5.1)
+    kgio (2.11.4)
+    mysql2 (0.5.4)
+    nokogiri (1.5.11)
+    rack (1.4.5)
+    rails_xss (0.4.0)
+    raindrops (0.20.0)
+    rake (13.0.6)
+    rdoc (4.3.0)
+    rdoc-data (4.1.0)
+      rdoc (~> 4.0)
+    rubyzip (0.9.9)
+    sqlite3 (1.4.4)
+    syntax (1.1.0)
+    unicorn (6.1.0)
+      kgio (~> 2.6)
+      raindrops (~> 0.7)
+    will_paginate (2.3.17)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  RedCloth (>= 4.0.0)
+  abstract (~> 1.0.0)
+  activerecord-mysql2-adapter
+  diff-lcs (~> 1.1.2)
+  erubis
+  file_signature (~> 1.2.0)
+  iconv
+  itextomml!
+  json (~> 2.5.1)
+  maruku!
+  mysql2
+  nokogiri (~> 1.5.6)
+  rack (= 1.4.5)
+  rails_xss (~> 0.4.0)
+  rake
+  rdoc
+  rdoc-data
+  rubyzip (~> 0.9.9)
+  sqlite3
+  syntax (~> 1.1.0)
+  unicorn
+  will_paginate (~> 2.3.15)
+
+BUNDLED WITH
+   1.17.3

--- a/vendor/rails/activesupport/lib/active_support/core_ext/bigdecimal/conversions.rb
+++ b/vendor/rails/activesupport/lib/active_support/core_ext/bigdecimal/conversions.rb
@@ -13,7 +13,7 @@ module ActiveSupport #:nodoc:
             alias_method :_original_to_s, :to_s
             alias_method :to_s, :to_formatted_s
 
-            yaml_as YAML_TAG
+            yaml_tag YAML_TAG
           end
         end
 


### PR DESCRIPTION
So far, using ruby 2.4.10, this PR (most notably) upgrades the gem for mysql.
See [issue 10](https://github.com/ncatlab/nlab-deployment/issues/10)